### PR TITLE
bumped async-native-tls to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "async-native-tls"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d57d4cec3c647232e1094dc013546c0b33ce785d8aeb251e1f20dfaf8a9a13fe"
+checksum = "9343dc5acf07e79ff82d0c37899f079db3534d99f189a1837c8e549c99405bec"
 dependencies = [
  "futures-util",
  "native-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,18 @@ edition = "2021"
 rust-version = "1.65.0"
 
 [dependencies]
-async-native-tls = {version = "0.4.0", default-features = false }
-async-std = {version = "1.12.0", features = ["attributes"], optional = true }
+async-native-tls = { version = "0.5.0", default-features = false }
+async-std = { version = "1.12.0", features = ["attributes"], optional = true }
 bytes = "1.4.0"
 futures = "0.3.28"
 log = "0.4.20"
 nom = "7.1.3"
-tokio = { version = "1.26.0", features = ["net", "time", "rt", "macros"], optional = true}
+tokio = { version = "1.26.0", features = [
+    "net",
+    "time",
+    "rt",
+    "macros",
+], optional = true }
 
 [dev-dependencies]
 env_logger = "0.10.0"


### PR DESCRIPTION
Hi, async-native-tls v0.4 is outdated. In a project of mine I had to use another dependency using v0.5 which is not compatible with v0.4 so I created a fork of async-pop. Bumping to v0.5 doesn't seem to influence the features.