### PR TITLE
Add LOGIN and more SASL mechanisms support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ use response::{
     uidl::UidlResponse,
     Response,
 };
+#[cfg(feature = "sasl")]
 use sasl::PlainAuthenticator;
 use stream::PopStream;
 
@@ -640,6 +641,7 @@ impl<S: Read + Write + Unpin + Send> Client<S> {
     ) -> Result<(Text, Text)> {
         self.check_client_state(ClientState::Authentication)?;
 
+        #[cfg(feature = "sasl")]
         if self.has_auth_mechanism("PLAIN") {
             let plain_auth = PlainAuthenticator::new(user.as_ref(), password.as_ref());
 


### PR DESCRIPTION
- Add LOGIN, DIGEST-MD5, NTLM, ANONYMOUS, EXTERNAL, SCRAM-SHA-1/256 to sasl_mechanism parser
- Fix conditional compilation for 'sasl' feature in lib.rs
- Add comprehensive tests for SASL mechanism parsing
- Fixes compatibility with QQ Enterprise Mail (pop.exmail.qq.com)